### PR TITLE
Adds support for BMP images

### DIFF
--- a/java/src/stanford/spl/JBECommand.java
+++ b/java/src/stanford/spl/JBECommand.java
@@ -46,10 +46,14 @@ import acm.util.TokenScanner;
 
 import java.awt.Color;
 import java.awt.Dimension;
+import java.awt.image.BufferedImage;
 import java.awt.Graphics2D;
 import java.awt.Toolkit;
 import java.lang.reflect.Method;
 import java.util.HashMap;
+
+import javax.imageio.ImageIO;
+import java.io.File;
 
 import javax.swing.JCheckBox;
 import javax.swing.JComboBox;
@@ -622,7 +626,8 @@ class GImage_create extends JBECommand {
       String filename = nextString(scanner);
       scanner.verifyToken(")");
       try {
-         GImage gobj = new GImage(filename);
+         BufferedImage img = ImageIO.read(new File(filename));
+         GImage gobj = new GImage(img);
          jbe.defineGObject(id, gobj);
          System.out.println("result:GDimension(" + gobj.getWidth() +
                             ", " + gobj.getHeight() + ")");


### PR DESCRIPTION
For some reason, acm's GImage isn't able to load BMP images when the
constructor that accepts a String is used. this gets over the problem
by loading the image in a BufferedImage and using GImage's constructor
that accepts an Image.
