### PR TITLE
Fixes bug in setting GLabel's label

### DIFF
--- a/java/src/stanford/spl/JBELabel.java
+++ b/java/src/stanford/spl/JBELabel.java
@@ -57,6 +57,10 @@ public class JBELabel extends GLabel {
       super.setColor(color);
       if (jlabel != null) jlabel.setForeground(color);
    }
-   
+  
+   public void setLabel(String s) {
+      if (jlabel == null) super.setLabel(s);
+      else jlabel.setText(s);
+   }
    private JLabel jlabel;
 }


### PR DESCRIPTION
when adding GLabel to a region, calling setLabel had no effect. this
was because JBELabel used a JLabel instead of a GLabel. calling
setLabel did not affect the JLabel but affected the GLabel. this fixes
the problem by handling the case where a JLabel is used.
