### PR TITLE
Fixes a bug setting a GSlider's size

### DIFF
--- a/c/include/gwindow.h
+++ b/c/include/gwindow.h
@@ -315,8 +315,8 @@ void addAt(GWindow gw, GObject gobj, double x, double y);
 void addToRegion(GWindow gw, GObject gobj, string region);
 
 /*
- * Function: remove
- * Usage: remove(gw, gobj);
+ * Function: removeGWindow
+ * Usage: removeGWindow(gw, gobj);
  * ------------------------
  * Removes the object from its container or region.
  */

--- a/doc/gwindow.html
+++ b/doc/gwindow.html
@@ -42,7 +42,7 @@ This interface defines an abstract type representing a graphics window.
 <tr><td class=indexKey><nobr><a href="#Function:add">add(gw,&nbsp;gobj)</a>&nbsp;</nobr></td><td class=indexSynopsis width=100%>Adds the <code>GObject</code> to the foreground layer of the window.</td></tr>
 <tr><td class=indexKey><nobr><a href="#Function:addAt">addAt(gw,&nbsp;gobj,&nbsp;x,&nbsp;y)</a>&nbsp;</nobr></td><td class=indexSynopsis width=100%>Adds the <code>GObject</code> to the foreground layer of the window after moving it to the point (<code>x</code>, <code>y</code>).</td></tr>
 <tr><td class=indexKey><nobr><a href="#Function:addToRegion">addToRegion(gw,&nbsp;gobj,&nbsp;region)</a>&nbsp;</nobr></td><td class=indexSynopsis width=100%>Adds the <code>GObject</code> (which must be an interactor or a label) to the control strip specified by <code>region</code>.</td></tr>
-<tr><td class=indexKey><nobr><a href="#Function:remove">remove(gw,&nbsp;gobj)</a>&nbsp;</nobr></td><td class=indexSynopsis width=100%>Removes the object from its container or region.</td></tr>
+<tr><td class=indexKey><nobr><a href="#Function:removeGWindow">removeGWindow(gw,&nbsp;gobj)</a>&nbsp;</nobr></td><td class=indexSynopsis width=100%>Removes the object from its container or region.</td></tr>
 <tr><td class=indexKey><nobr><a href="#Function:getGObjectAt">getGObjectAt(gw,&nbsp;x,&nbsp;y)</a>&nbsp;</nobr></td><td class=indexSynopsis width=100%>Returns a pointer to the topmost <code>GObject</code> containing the point (<code>x</code>, <code>y</code>), or <code>NULL</code> if no such object exists.</td></tr>
 <tr><td class=indexKey><nobr><a href="#Function:setRegionAlignment">setRegionAlignment(gw,&nbsp;region,&nbsp;align)</a>&nbsp;</nobr></td><td class=indexSynopsis width=100%>Sets the alignment of the specified side region as specified by the string <code>align</code>.</td></tr>
 <tr><td class=indexKey><nobr><a href="#Function:pause">pause(milliseconds)</a>&nbsp;</nobr></td><td class=indexSynopsis width=100%>Pauses for the indicated number of milliseconds.</td></tr>
@@ -404,16 +404,16 @@ or <code>"WEST"</code>.
 addToRegion(gw, gobj, region);
 </pre>
 <hr>
-<a name="Function:remove"></a>
+<a name="Function:removeGWindow"></a>
 <pre class=detailCode>
-void remove(GWindow gw, GObject gobj);
+void removeGWindow(GWindow gw, GObject gobj);
 </pre>
 <div class=detailHTML>
 Removes the object from its container or region.
 <p>Usage:<br>
 </div>
 <pre class=usageCode>
-remove(gw, gobj);
+removeGWindow(gw, gobj);
 </pre>
 <hr>
 <a name="Function:getGObjectAt"></a>

--- a/java/src/stanford/spl/GInteractor.java
+++ b/java/src/stanford/spl/GInteractor.java
@@ -87,7 +87,9 @@ public abstract class GInteractor extends GObject implements GResizable {
    public void setSize(double width, double height) {
       int iw = GMath.round(width);
       int ih = GMath.round(height);
-      interactor.setPreferredSize(new Dimension(iw, ih));
+      Dimension d = new Dimension(iw, ih);
+      interactor.setPreferredSize(d);
+      interactor.setMinimumSize(d);
       interactor.setSize(iw, ih);
       interactor.repaint();
    }

--- a/java/src/stanford/spl/JBELabel.java
+++ b/java/src/stanford/spl/JBELabel.java
@@ -57,6 +57,10 @@ public class JBELabel extends GLabel {
       super.setColor(color);
       if (jlabel != null) jlabel.setForeground(color);
    }
-   
+  
+   public void setLabel(String s) {
+      if (jlabel == null) super.setLabel(s);
+      else jlabel.setText(s);
+   }
    private JLabel jlabel;
 }


### PR DESCRIPTION
when adding a `GSlider` to a region, setting its size did not work
because of the use of a layout manager that works by getting the
minimum size. setting a minimum size fixed the problem.
