### PR TITLE
Fixes a bug calling setFilled on a GLabel

### DIFF
--- a/c/src/gobjects.c
+++ b/c/src/gobjects.c
@@ -323,6 +323,11 @@ void setBounds(GObject gobj, double x, double y, double width, double height) {
 }
 
 void setFilled(GObject gobj, bool flag) {
+   // ensure gobj has valid type
+   if ((gobj->type &
+       (G3DRECT | GARC | GOVAL | GPOLYGON | GRECT | GROUNDRECT)) == 0) {
+      error("setFilled: Illegal GObject type");
+   }
    gobj->filled = flag;
    setFilledOp(gobj, flag);
 }


### PR DESCRIPTION
when calling `setFilled` on a `GLabel`, an error was produced on the
back-end because `GLabel` is not `GFillable`.

this fixes the bug on the "C wrapper" level by ensuring `setFilled` is
called on a `GFillable`. a more elegant error message is produced
otherwise.
