### PR TITLE
Sets make to use bash instead of sh

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,8 @@
 # ****************************************************************
 # Makefile for SPL
 
+SHELL=/bin/bash
+
 BUILD = \
     build \
     build/classes \


### PR DESCRIPTION
it turns out that `make` by default uses `/bin/sh` instead of
`/bin/bash` which caused the `make install` command to fail because
`sh` does not support brace expansion.

setting the `SHELL` variable in the `Makefile` to `/bin/bash` fixed
the problem.
