### PR TITLE
containsGPolygon should take a polygon, not an arc

### DIFF
--- a/c/src/gobjects.c
+++ b/c/src/gobjects.c
@@ -748,13 +748,13 @@ static GRectangle getBoundsGPolygon(GPolygon poly) {
    return createGRectangle(xMin, yMin, xMax - xMin, yMax - yMin);
 }
 
-static bool containsGPolygon(GArc arc, double x, double y) {
+static bool containsGPolygon(GPolygon poly, double x, double y) {
    double x0, y0, x1, y1;
    int crossings, i, n;
    GPoint *p0, *p1;
    Vector vertices;
 
-   vertices = arc->u.polygonRep.vertices;
+   vertices = poly->u.polygonRep.vertices;
    crossings = 0;
    n = sizeVector(vertices);
    if (n < 2) return false;


### PR DESCRIPTION
Seems like this is probably just  a typo (which the compiler didn't catch because `GPolygon` and `GArc` are both just `typedef`d to `GObject`). The function accesses the `polygonRep` union variant and is called in `containsGObject` after confirming the type is indeed a polygon.